### PR TITLE
(feat)新增了'docker-compose.yml'及'init.sql'文件，方便部署本地环境

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  db:
+    image: mysql
+    container_name: emby-db
+    restart: always
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: emby-bot-db
+      MYSQL_USER: embyplus
+      MYSQL_PASSWORD: embyplus
+    volumes:
+      - ./data/db:/var/lib/mysql
+      - ./data/init.sql:/docker-entrypoint-initdb.d/init.sql
+    networks:
+      - emby-network
+
+  emby:
+    image: emby/embyserver
+    container_name: embyserver
+    environment:
+      - UID=1000 # The UID to run emby as (default: 2)
+      - GID=100 # The GID to run emby as (default 2)
+      - GIDLIST=100 # A comma-separated list of additional GIDs to run emby as (default: 2)
+    volumes:
+      - ./emby/programdata:/config # Configuration directory
+      - ./emby/tvshows:/mnt/share1 # Media directory
+      - ./emby/movies:/mnt/share2 # Media directory
+    ports:
+      - 8096:8096 # HTTP port
+      - 8920:8920 # HTTPS port
+    restart: always
+    networks:
+      - emby-network
+
+networks:
+  emby-network:
+

--- a/backend/init.sql
+++ b/backend/init.sql
@@ -1,0 +1,16 @@
+-- 创建数据库
+CREATE DATABASE IF NOT EXISTS emby_bot_db;
+
+-- 切换到 root 用户（如果有需要）
+USE mysql;
+
+-- 为新用户 "embyplus" 授予权限
+CREATE USER IF NOT EXISTS 'embyplus'@'%' IDENTIFIED BY 'embyplus';
+GRANT ALL PRIVILEGES ON *.* TO 'embyplus'@'%';
+
+-- 刷新权限
+FLUSH PRIVILEGES;
+
+-- 返回到默认数据库
+USE emby_bot_db;
+


### PR DESCRIPTION
在backend目录中新增加了docker-compose.yml文件及‘init.sql’文件，可以快速部署本地后端环境

## Summary by Sourcery

添加 Docker Compose 设置以便于本地部署。

构建：
- 引入 `docker-compose.yml` 文件，使用 Docker 定义和管理本地后端环境。

部署：
- 添加初始化 SQL 脚本 `init.sql`，为本地后端部署设置所需的数据库和用户权限。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a Docker Compose setup to facilitate local deployments.

Build:
- Introduce a `docker-compose.yml` file to define and manage the local backend environment using Docker.

Deployment:
- Add an initialization SQL script `init.sql` to set up the required databases and user permissions for the local backend deployment.

</details>