### PR TITLE
fix(logger): 修复logger无法显示debug级别日志的问题

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,11 +52,16 @@ async def _init_db() -> None:
 def _init_logger() -> None:
     """初始化日志记录器。"""
     handler = logging.StreamHandler()  # 输出到终端
+    fmt = "%(levelname)s [%(asctime)s] %(name)s - %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
     formatter = logging.Formatter(
-        fmt="%(levelname)s [%(asctime)s] %(name)s - %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
+        fmt=fmt,
+        datefmt=datefmt,
     )
     handler.setFormatter(formatter)
+
+    # 设置日志默认值
+    logging.basicConfig(format=fmt, datefmt=datefmt, level=config.log_level)
 
     # 添加流处理器
     logger.addHandler(handler)


### PR DESCRIPTION
## Sourcery 总结

将默认日志级别设置为配置的日志级别。

Bug 修复:
- 修复了日志记录器，通过将默认日志级别设置为配置的日志级别来显示调试级别日志，如果配置的日志级别设置为调试或更低，则可以显示调试日志。
- 修复了日志记录器，通过将默认日志级别设置为配置的日志级别来显示调试级别日志，如果配置的日志级别设置为调试或更低，则可以显示调试日志。
- 修复了日志记录器，通过将默认日志级别设置为配置的日志级别来显示调试级别日志，如果配置的日志级别设置为调试或更低，则可以显示调试日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Set the default log level to the configured log level.

Bug Fixes:
- Fix the logger to display debug level logs by setting the default log level to the configured log level, which enables debug logs to be displayed if the configured log level is set to debug or lower.
- Fix the logger to display debug level logs by setting the default log level to the configured log level, which enables debug logs to be displayed if the configured log level is set to debug or lower.
- Fix the logger to display debug level logs by setting the default log level to the configured log level, which enables debug logs to be displayed if the configured log level is set to debug or lower.

</details>