### PR TITLE
feat: Enhance group membership filter and error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__
 *.log
 *.session
 *.session-journal
+venv/
+.vscode/

--- a/bot/commands.py
+++ b/bot/commands.py
@@ -22,6 +22,7 @@ from bot.utils import parse_iso8601_to_normal_date
 from config import config
 from models.invite_code_model import InviteCodeType
 from services import UserService
+from services.user_service import NotBoundError
 
 logger = logging.getLogger(__name__)
 
@@ -146,8 +147,12 @@ class CommandHandler:
                     reply_text += f"• 被ban原因：<code>{user.reason}</code>\n"
 
             await self._reply_html(message, reply_text)
+        except NotBoundError as e:
+            await self._reply_html(message, f"查询失败：{str(e)}")
+            return
         except Exception as e:
             await self._send_error(message, e, prefix="查询失败")
+            return
 
     @ensure_args(1, "/use_code <邀请码>")
     async def use_code(self, message: Message, args: list[str]):
@@ -501,25 +506,25 @@ class CommandHandler:
             await self.help_command(message)
 
         @self.bot_client.client.on_message(
-            filters.command("count") & user_in_group_on_filter
+            filters.command("count") & user_in_group_on_filter()
         )
         async def c_count(client, message):
             await self.count(message)
 
         @self.bot_client.client.on_message(
-            filters.command("info") & user_in_group_on_filter
+            filters.command("info") & user_in_group_on_filter()
         )
         async def c_info(client, message):
             await self.info(message)
 
         @self.bot_client.client.on_message(
-            filters.private & filters.command("use_code") & user_in_group_on_filter
+            filters.private & filters.command("use_code") & user_in_group_on_filter()
         )
         async def c_use_code(client, message):
             await self.use_code(message)
 
         @self.bot_client.client.on_message(
-            filters.private & filters.command("create") & user_in_group_on_filter
+            filters.private & filters.command("create") & user_in_group_on_filter()
         )
         async def c_create_user(client, message):
             await self.create_user(message)
@@ -527,7 +532,7 @@ class CommandHandler:
         @self.bot_client.client.on_message(
             filters.private
             & filters.command("reset_emby_password")
-            & user_in_group_on_filter
+            & user_in_group_on_filter()
             & emby_user_on_filter
         )
         async def c_reset_emby_password(client, message):
@@ -536,7 +541,7 @@ class CommandHandler:
         @self.bot_client.client.on_message(
             filters.private
             & filters.command("select_line")
-            & user_in_group_on_filter
+            & user_in_group_on_filter()
             & emby_user_on_filter
         )
         async def c_select_line(client, message):

--- a/bot/filters.py
+++ b/bot/filters.py
@@ -8,18 +8,32 @@ from services import UserService
 logger = logging.getLogger(__name__)
 
 
-async def user_in_group_on_filter(filter, client, update) -> bool:
-    user = update.from_user or update.sender_chat
-    telegram_id = user.id
-    if config.group_members and telegram_id in config.group_members:
-        logger.debug(f"User {telegram_id} is in group")
-        return True
-    if config.channel_members and telegram_id in config.channel_members:
-        logger.debug(f"User {telegram_id} is in channel")
-        return True
-
-    logger.debug(f"User {telegram_id} is not in group or channel")
+async def check_group_membership(client, message) -> bool:
+    """检查用户是否在任一配置中的群聊中。"""
+    user_id = message.from_user.id
+    for group_id in config.telegram_group_ids:
+        try:
+            member = await client.get_chat_member(group_id, user_id)
+            if member and member.status:
+                logger.debug(f"用户 {user_id} 已加入群 {group_id}")
+                return True
+        except Exception as e:
+            logger.debug(f"查询用户 {user_id} 在群 {group_id} 的信息失败：{e}")
+            continue
     return False
+
+
+def user_in_group_on_filter():
+    """自定义过滤器：判断用户是否在指定群组中；如果不在则回复提示。"""
+    async def custom_filter(flt, client, message):
+        if await check_group_membership(client, message):
+            return True
+        try:
+            await message.reply("❌ 请先加入指定的群聊后再使用本命令。")
+        except Exception as exc:
+            logger.error(f"回复提示消息失败：{exc}")
+        return False
+    return create(custom_filter)
 
 
 async def admin_user_on_filter(filter, client, update) -> bool:
@@ -31,9 +45,7 @@ async def admin_user_on_filter(filter, client, update) -> bool:
             logger.debug(f"User {telegram_id} is an admin")
             return True
     except Exception as e:
-        logger.error(
-            f"Error checking admin status for user {telegram_id}: {e}", exc_info=True
-        )
+        logger.error(f"Error checking admin status for user {telegram_id}: {e}", exc_info=True)
         return False
 
     logger.debug(f"User {telegram_id} is not an admin")
@@ -49,15 +61,12 @@ async def emby_user_on_filter(filter, client, update) -> bool:
             logger.debug(f"User {telegram_id} is an Emby user")
             return True
     except Exception as e:
-        logger.error(
-            f"Error checking Emby status for user {telegram_id}: {e}", exc_info=True
-        )
+        logger.error(f"Error checking Emby status for user {telegram_id}: {e}", exc_info=True)
         return False
 
     logger.debug(f"User {telegram_id} is not an Emby user")
     return False
 
 
-user_in_group_on_filter = create(user_in_group_on_filter, "user_in_group_on_filter")
 admin_user_on_filter = create(admin_user_on_filter, "admin_user_on_filter")
 emby_user_on_filter = create(emby_user_on_filter, "emby_user_on_filter")

--- a/services/user_service.py
+++ b/services/user_service.py
@@ -17,6 +17,9 @@ from models.user_model import UserOrm
 
 logger = logging.getLogger(__name__)
 
+class NotBoundError(Exception):
+    """用户未绑定 Emby 账号的异常"""
+    pass
 
 class UserService:
     """用户与 Emby 相关的业务逻辑层"""
@@ -134,12 +137,10 @@ class UserService:
         """获取当前用户在 Emby 的信息"""
         user = await self.must_get_user(telegram_id)
         if not user.has_emby_account():
-            raise Exception("该用户尚未绑定 Emby 账号。")
+            raise NotBoundError("该用户尚未绑定 Emby 账号。")
         emby_user = self.emby_api.get_user(str(user.emby_id))
         if not emby_user:
-            raise Exception(
-                "从 Emby 服务器获取用户信息失败，请检查 Emby 服务是否正常。"
-            )
+            raise Exception("从 Emby 服务器获取用户信息失败，请检查 Emby 服务是否正常。")
         return user, emby_user
 
     async def first_or_create_emby_config(self) -> Config:


### PR DESCRIPTION
- Refactored `user_in_group_on_filter` to dynamically check group membership
- Added custom filter to check and notify users about group membership
- Introduced `NotBoundError` for clearer Emby account binding error handling
- Updated command handlers to use new filter and error handling

好的，这是将给定的 pull request 总结翻译成中文的结果：

## Sourcery 总结

此 pull request 通过添加群组成员资格过滤器和改进错误处理来增强了 bot 的功能。它引入了一个自定义过滤器，用于检查用户是否是指定的 Telegram 群组的成员，然后才允许他们使用某些命令，如果他们不是成员，则会通知他们。它还通过引入 `NotBoundError` 异常来改进 Emby 帐户绑定的错误处理。

新功能：
- 引入了一个自定义过滤器，用于检查用户是否是指定的 Telegram 群组的成员，然后才允许他们使用某些命令，如果他们不是成员，则会通知他们。

Bug 修复：
- 通过引入 `NotBoundError` 异常来改进 Emby 帐户绑定的错误处理，当用户的 Emby 帐户未绑定时，向用户提供更清晰的错误消息。

增强功能：
- 重构了群组成员资格检查，以动态验证用户在配置的 Telegram 群组中的成员资格，从而提高了准确性和灵活性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

This pull request enhances the bot's functionality by adding a group membership filter and improving error handling. It introduces a custom filter to check if a user is a member of specified Telegram groups before allowing them to use certain commands, notifying them if they are not a member. It also improves error handling for Emby account binding by introducing a `NotBoundError` exception.

New Features:
- Introduces a custom filter that checks if a user is a member of specified Telegram groups before allowing them to use certain commands, notifying them if they are not a member.

Bug Fixes:
- Improves error handling for Emby account binding by introducing a `NotBoundError` exception, providing clearer error messages to users when their Emby account is not bound.

Enhancements:
- Refactors the group membership check to dynamically verify user membership in configured Telegram groups, improving accuracy and flexibility.

</details>